### PR TITLE
update on Invitation Status

### DIFF
--- a/LetsDinnerV2 MessagesExtension/Controller/EventSummaryVC/EventSummaryViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/EventSummaryVC/EventSummaryViewController.swift
@@ -11,7 +11,7 @@ import EventKit
 
 protocol EventSummaryViewControllerDelegate: class {
     func eventSummaryVCOpenTasksList(controller: EventSummaryViewController)
-    func eventSummaryVCDidAnswer(hasAccepted: Bool, controller: EventSummaryViewController)
+    func eventSummaryVCDidAnswer(hasAccepted: Invitation, controller: EventSummaryViewController)
     func eventSummaryVCOpenEventInfo(controller: EventSummaryViewController)
 }
 
@@ -71,7 +71,7 @@ class EventSummaryViewController: UIViewController {
         summaryTableView.register(UINib(nibName: nibName, bundle: nil), forCellReuseIdentifier: nibName)
     }
     
-    private func isUsertheHost() -> Bool {
+    func isUsertheHost() -> Bool {
         guard let currentUser = Event.shared.currentUser else { return false }
         if Event.shared.participants.contains(where: { $0.identifier == currentUser.identifier
         }) {
@@ -107,9 +107,9 @@ extension EventSummaryViewController: UITableViewDelegate, UITableViewDataSource
             
         case RowItemNumber.answerCell.rawValue:
             
-            if Event.shared.currentUser?.hasAccepted == false {
+            if Event.shared.currentUser?.hasAccepted == .declined {
                 return answerDeclinedCell
-            } else if Event.shared.currentUser?.hasAccepted == true {
+            } else if Event.shared.currentUser?.hasAccepted == .accepted {
                 return answerAcceptedCell
             }
 
@@ -117,7 +117,7 @@ extension EventSummaryViewController: UITableViewDelegate, UITableViewDataSource
             return answerCell
 
         case RowItemNumber.hostInfo.rawValue:
-            if Event.shared.currentUser?.hasAccepted == true {
+            if Event.shared.currentUser?.hasAccepted == .accepted {
                 infoCell.titleLabel.text = LabelStrings.eventInfo
                 infoCell.infoLabel.text = Event.shared.hostName + "  >"
             } else {
@@ -166,23 +166,13 @@ extension EventSummaryViewController: UITableViewDelegate, UITableViewDataSource
         // 3 conditions: accept(/Host) / Neutral / or decline)
         
         // Default Height:
-//        switch indexPath.row {
-//        case RowItemNumber.answerCell.rawValue:
-//            return 120
-//        case RowItemNumber.hostInfo.rawValue:
-//            return 52
-//        case RowItemNumber.dateInfo.rawValue,
-//             RowItemNumber.locationInfo.rawValue:
-//            return 52
-//        case RowItemNumber.taskInfo.rawValue:
-//            return 257
-//        case RowItemNumber.userInfo.rawValue:
-//            return 150
-//        default:
-//            return UITableView.automaticDimension
-//        }
-                
-        if Event.shared.currentUser?.hasAccepted == true {
+        //title auto
+        //answerCell = 120
+        //hostInfo, locationInfo, dateInfo = 52
+        //taskInfo: 257
+        //userInfo: 150
+        
+        if Event.shared.currentUser?.hasAccepted == .accepted {
             // Accept or Host
             switch indexPath.row {
             case RowItemNumber.answerCell.rawValue:
@@ -202,7 +192,7 @@ extension EventSummaryViewController: UITableViewDelegate, UITableViewDataSource
                 return UITableView.automaticDimension
             }
             
-        } else if Event.shared.currentUser?.hasAccepted == false {
+        } else if Event.shared.currentUser?.hasAccepted == .declined {
             // Decline Status
             switch indexPath.row {
             case RowItemNumber.answerCell.rawValue:
@@ -306,11 +296,11 @@ extension EventSummaryViewController: UITableViewDelegate, UITableViewDataSource
 
 extension EventSummaryViewController: AnswerCellDelegate {
     func didTapAccept() {
-        delegate?.eventSummaryVCDidAnswer(hasAccepted: true, controller: self)
+        delegate?.eventSummaryVCDidAnswer(hasAccepted: .accepted, controller: self)
     }
     
     func didTapDecline() {
-        delegate?.eventSummaryVCDidAnswer(hasAccepted: false, controller: self)
+        delegate?.eventSummaryVCDidAnswer(hasAccepted: .declined, controller: self)
     }
     
     func addToCalendarAlert() {
@@ -359,7 +349,7 @@ extension EventSummaryViewController: TaskSummaryCellDelegate {
     func taskSummaryCellDidTapSeeAll() {
         if let index = Event.shared.participants.firstIndex (where: { $0.identifier == Event.shared.currentUser?.identifier }) {
             let user = Event.shared.participants[index]
-            if user.hasAccepted {
+            if user.hasAccepted == .accepted {
                 delegate?.eventSummaryVCOpenTasksList(controller: self)
             } else {
                 presentAlert(MessagesToDisplay.declinedInvitation)

--- a/LetsDinnerV2 MessagesExtension/Controller/MessagesViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/MessagesViewController.swift
@@ -22,7 +22,6 @@ class MessagesViewController: MSMessagesAppViewController {
         if FirebaseApp.app() == nil {
                FirebaseApp.configure()
         }
-        
     }
     
     // MARK: - Conversation Handling
@@ -36,8 +35,13 @@ class MessagesViewController: MSMessagesAppViewController {
     
     override func didBecomeActive(with conversation: MSConversation) {
         guard let currentUserUid = activeConversation?.localParticipantIdentifier.uuidString else { return }
+        
         if Event.shared.currentUser == nil {
-            Event.shared.currentUser = User(identifier: currentUserUid, fullName: defaults.username, hasAccepted: false)
+            
+            // Initiate a new user
+            Event.shared.currentUser = User(identifier: currentUserUid,
+                                            fullName: defaults.username,
+                                            hasAccepted: .pending)
         }
     }
     
@@ -59,10 +63,19 @@ class MessagesViewController: MSMessagesAppViewController {
     }
     
     override func didStartSending(_ message: MSMessage, conversation: MSConversation) {
-         if !Event.shared.participants.contains(where: { $0.identifier == Event.shared.currentUser?.identifier }) {
-                   Event.shared.acceptInvitation(Event.shared.currentUser?.hasAccepted)
-               }
-               Event.shared.updateFirebaseTasks()
+        // Auto Accept the dinner for host creating event
+        guard let currentUser = Event.shared.currentUser else {return}
+        
+        if !Event.shared.isHostRegistered && !Event.shared.participants.contains(where: { $0.identifier == Event.shared.currentUser?.identifier }) {
+            
+            //Testing case: accept or decline
+            currentUser.hasAccepted = .accepted
+            Event.shared.isHostRegistered = true
+            Event.shared.acceptInvitation(hasAccepted: currentUser.hasAccepted)
+        }
+        
+        
+        Event.shared.updateFirebaseTasks()
     }
     
     override func didCancelSending(_ message: MSMessage, conversation: MSConversation) {
@@ -79,6 +92,7 @@ class MessagesViewController: MSMessagesAppViewController {
     
     override func didTransition(to presentationStyle: MSMessagesAppPresentationStyle) {
         super.didTransition(to: presentationStyle)
+        
         guard let conversation = activeConversation else { fatalError("Expected an active converstation") }
         presentViewController(for: conversation, with: presentationStyle)
         print(#function)
@@ -100,6 +114,7 @@ class MessagesViewController: MSMessagesAppViewController {
                 controller = instantiateIdleViewController()
             }
         } else {
+            //Expanded Style
             if defaults.username.isEmpty || newNameRequested {
                 newNameRequested = false
                 controller = instantiateRegistrationViewController()
@@ -413,19 +428,22 @@ extension MessagesViewController: ReviewViewControllerDelegate {
 }
 
 extension MessagesViewController: EventSummaryViewControllerDelegate {
+    
     func eventSummaryVCOpenTasksList(controller: EventSummaryViewController) {
         let controller = instantiateTasksListViewController()
         removeAllChildViewControllers()
         addChildViewController(controller: controller)
     }
     
-    func eventSummaryVCDidAnswer(hasAccepted: Bool, controller: EventSummaryViewController) {
-        if hasAccepted {
+    func eventSummaryVCDidAnswer(hasAccepted: Invitation, controller: EventSummaryViewController) {
+        if hasAccepted == .accepted {
             Event.shared.summary = defaults.username + MessagesToDisplay.acceptedInvitation
-        } else {
+        } else if hasAccepted == .declined {
             Event.shared.summary = defaults.username + MessagesToDisplay.declinedInvitation
         }
+        
         Event.shared.currentUser?.hasAccepted = hasAccepted
+        
         let currentSession = activeConversation?.selectedMessage?.session ?? MSSession()
         let message = Event.shared.prepareMessage(session: currentSession, eventCreation: false)
         sendMessage(message: message)

--- a/LetsDinnerV2 MessagesExtension/Extensions/UserDefaults.swift
+++ b/LetsDinnerV2 MessagesExtension/Extensions/UserDefaults.swift
@@ -18,4 +18,9 @@ extension UserDefaults {
         get { return string(forKey: "profilePicUrl") ?? "" }
         set { set(newValue, forKey: "profilePicUrl") }
     }
+    
+    var hasAccepted: String {
+        get { return string(forKey: "hasAccepted") ?? ""}
+        set { set(newValue, forKey: "hasAccepted")}
+    }
 }

--- a/LetsDinnerV2 MessagesExtension/Model/Constants.swift
+++ b/LetsDinnerV2 MessagesExtension/Model/Constants.swift
@@ -19,7 +19,6 @@ enum Colors {
     static let hasDeclined = UIColor(red:0.82, green:0.01, blue:0.11, alpha:1.0)
     static let paleGray = UIColor(red: 242/255, green: 242/255, blue: 247/255, alpha: 1.0)
     static let dullGray = UIColor(red: 138/255, green: 138/255, blue: 142/255, alpha: 1.0)
-    
     static let newGradientPink = UIColor(red: 255/255, green: 111/255, blue: 133/255, alpha: 1.0)
     static let newGradientRed = UIColor(red: 255/255, green: 73/255, blue: 72/255, alpha: 1.0)
 }
@@ -104,5 +103,4 @@ enum LabelStrings {
     static let whatsThePlan = "So, what's the plan?"
     static let nothingToDo = "There is nothing to do!"
     static let readyToSend = "Ready to send your invite?"
-    
 }

--- a/LetsDinnerV2 MessagesExtension/Model/DataHelper.swift
+++ b/LetsDinnerV2 MessagesExtension/Model/DataHelper.swift
@@ -90,10 +90,5 @@ class DataHelper {
         }
         dataTask.resume()
         
-    }
-    
-   
-    
-    
-    
+    } 
 }

--- a/LetsDinnerV2 MessagesExtension/Model/User.swift
+++ b/LetsDinnerV2 MessagesExtension/Model/User.swift
@@ -11,13 +11,18 @@ import Foundation
 class User {
     var identifier: String
     var fullName: String
-    var hasAccepted: Bool
+    var hasAccepted: Invitation
     var profilePicUrl: String? 
     
-    init(identifier: String, fullName: String, hasAccepted: Bool) {
+    init(identifier: String, fullName: String, hasAccepted: Invitation) {
         self.identifier = identifier
         self.fullName = fullName
         self.hasAccepted = hasAccepted
     }
- 
+}
+
+enum Invitation: String {
+    case pending = "Pending"
+    case accepted = "Accepted"
+    case declined = "Declined"
 }

--- a/LetsDinnerV2 MessagesExtension/View/Cells/AnswerCell/AnswerCell.xib
+++ b/LetsDinnerV2 MessagesExtension/View/Cells/AnswerCell/AnswerCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="AnswerCell" rowHeight="162" id="KGk-i7-Jjw" customClass="AnswerCell" customModule="Let_s_Dinner_" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AnswerCell" rowHeight="162" id="KGk-i7-Jjw" customClass="AnswerCell" customModule="Let_s_Dinner_" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/LetsDinnerV2 MessagesExtension/View/Cells/UserCVCell/UserCVCell.swift
+++ b/LetsDinnerV2 MessagesExtension/View/Cells/UserCVCell/UserCVCell.swift
@@ -19,7 +19,12 @@ class UserCVCell: UICollectionViewCell {
     
     func configureCell(user: User) {
         var strokeColor = UIColor()
-        strokeColor = user.hasAccepted ? Colors.hasAccepted : Colors.hasDeclined
+        
+        if user.hasAccepted == .accepted {
+            strokeColor = Colors.hasAccepted
+        } else if user.hasAccepted == .declined || user.hasAccepted == .pending {
+            strokeColor = Colors.hasDeclined
+        }
         
         if let imageURL = URL(string: user.profilePicUrl!) {
             userPicture.layer.cornerRadius = userPicture.frame.height/2
@@ -30,8 +35,6 @@ class UserCVCell: UICollectionViewCell {
         } else {
             userPicture.setImage(string: user.fullName.initials, color: .lightGray, circular: true, stroke: true, strokeColor: strokeColor, textAttributes: [NSAttributedString.Key(rawValue: NSAttributedString.Key.font.rawValue): UIFont.systemFont(ofSize: 20, weight: .light), NSAttributedString.Key.foregroundColor: UIColor.white])
         }
-        
-        
         
         nameLabel.text = user.fullName
     }


### PR DESCRIPTION
Testing on the status is super complexed because the simulator sucks.

```currentUserUid = activeConversation?.localParticipantIdentifier.uuidString```

Because of the local Identifier is saved according to the appleID, so there is not difference using Kate or John in the simulator, they are literally the same person. Thats why it is so difficult to test the expected responding from the invitee, actually it took large amount of time, except if we can find way to solve this problem