### PR TITLE
- update on the label where it shows 🦾only after ios 13.2

### DIFF
--- a/LetsDinnerV2 MessagesExtension/Controller/CustomRecipeDetailsVC/CustomRecipeDetailsViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/CustomRecipeDetailsVC/CustomRecipeDetailsViewController.swift
@@ -34,7 +34,8 @@ class CustomRecipeDetailsViewController: UIViewController {
     @IBOutlet weak var ingredientsHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var stepsHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var contentViewHeightConstraint: NSLayoutConstraint!
-    
+    @IBOutlet weak var bottomView: UIView!
+    @IBOutlet weak var bottomViewHeightConstraint: NSLayoutConstraint!
     
     var selectedRecipe: CustomRecipe?
     
@@ -86,6 +87,12 @@ class CustomRecipeDetailsViewController: UIViewController {
         stepsTableView.estimatedRowHeight = rowHeight
         ingredientsHeightConstraint.constant = CGFloat(recipe.ingredients.count) * rowHeight
         let isSelected = Event.shared.selectedCustomRecipes.contains(where: { $0.title == recipe.title })
+        
+        if UIDevice.current.hasHomeButton {
+            bottomViewHeightConstraint.constant = 60
+            self.bottomView.layoutIfNeeded()
+        }
+        
         chooseButton.isHidden = isSelected
         chosenButton.isHidden = !isSelected
         recipeImageView.layer.cornerRadius = 17

--- a/LetsDinnerV2 MessagesExtension/Controller/CustomRecipeDetailsVC/CustomRecipeDetailsViewController.xib
+++ b/LetsDinnerV2 MessagesExtension/Controller/CustomRecipeDetailsVC/CustomRecipeDetailsViewController.xib
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CustomRecipeDetailsViewController" customModule="Let_s_Dinner_" customModuleProvider="target">
             <connections>
+                <outlet property="bottomView" destination="fl5-Xs-l0q" id="sYN-Uf-avw"/>
+                <outlet property="bottomViewHeightConstraint" destination="hRQ-1Q-ng7" id="dgf-GI-oLC"/>
                 <outlet property="chooseButton" destination="sTL-uv-Asu" id="mZj-6R-pVs"/>
                 <outlet property="chosenButton" destination="8gT-hO-Zv7" id="Yrt-l4-ECQ"/>
                 <outlet property="commentsLabel" destination="HA5-xu-nuh" id="2BV-yn-XQo"/>
@@ -200,7 +202,7 @@
                     <rect key="frame" x="0.0" y="634" width="375" height="83"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uzg-cE-3VE">
-                            <rect key="frame" x="18" y="18" width="30" height="33"/>
+                            <rect key="frame" x="18" y="13" width="30" height="33"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <state key="normal" title="Edit">
                                 <color key="titleColor" red="0.8784313725490196" green="0.38823529411764707" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -212,9 +214,9 @@
                     </subviews>
                     <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="83" id="dSh-ee-R2J"/>
+                        <constraint firstAttribute="height" constant="83" id="hRQ-1Q-ng7"/>
                         <constraint firstItem="uzg-cE-3VE" firstAttribute="leading" secondItem="fl5-Xs-l0q" secondAttribute="leading" constant="18" id="k2p-xg-Kds"/>
-                        <constraint firstItem="uzg-cE-3VE" firstAttribute="top" secondItem="fl5-Xs-l0q" secondAttribute="top" constant="18" id="loj-ub-euV"/>
+                        <constraint firstItem="uzg-cE-3VE" firstAttribute="top" secondItem="fl5-Xs-l0q" secondAttribute="top" constant="13" id="loj-ub-euV"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pLJ-eD-KGQ" userLabel="HeaderView">

--- a/LetsDinnerV2 MessagesExtension/Controller/ManagementVC/ManagementViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/ManagementVC/ManagementViewController.swift
@@ -16,20 +16,21 @@ protocol ManagementViewControllerDelegate: class {
 
 class ManagementViewController: UIViewController {
     
-    @IBOutlet private weak var progressView: UIProgressView!
     @IBOutlet private weak var backButton: UIButton!
     @IBOutlet private weak var nextButton: UIButton!
     @IBOutlet private weak var tasksTableView: UITableView!
     @IBOutlet private weak var addButton: UIButton!
     @IBOutlet private weak var servingsLabel: UILabel!
-    @IBOutlet private weak var servingsStepperOld: UIStepper!
-    @IBOutlet private weak var servingsStepper: GMStepper!
+    @IBOutlet private weak var servingsStepper: UIStepper!
+    @IBOutlet private weak var servingsFancyStepper: GMStepper!
     @IBOutlet weak var separatorView: UIView!
     
     @IBOutlet weak var addThingView: UIView!
     @IBOutlet weak var newThingTextField: UITextField!
     @IBOutlet weak var addThingViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var sectionSelectionInput: SectionSelectionInput!
+    @IBOutlet weak var bottomView: UIView!
+    @IBOutlet weak var bottomViewHeightConstraint: NSLayoutConstraint!
     
     weak var delegate: ManagementViewControllerDelegate?
     
@@ -39,7 +40,7 @@ class ManagementViewController: UIViewController {
     private var sectionNames = [String]()
     private var servings : Int = 2 {
         didSet {
-            servingsLabel.text = "How many servings?"
+            servingsLabel.text = "How many servings?  \(servings)"
             Event.shared.servings = servings
         }
     }
@@ -80,37 +81,33 @@ class ManagementViewController: UIViewController {
     }
     
     private func setupUI() {
-//        progressView.progressTintColor = Colors.newGradientRed
-//        progressView.trackTintColor = .white
-//        progressView.progress = 2/5
-//        progressView.setProgress(3/5, animated: true)
         
         tasksTableView.tableFooterView = UIView()
         
         servingsLabel.text = "How many servings?  \(servings)"
         servingsLabel.textColor = Colors.textGrey
         
-//        servingsStepperOld.minimumValue = 2
-//        servingsStepperOld.maximumValue = 12
-//        servingsStepperOld.stepValue = 1
-//        servingsStepperOld.value = Double(servings)
-        
         servingsStepper.minimumValue = 2
         servingsStepper.maximumValue = 12
         servingsStepper.stepValue = 1
         servingsStepper.value = Double(servings)
-        servingsStepper.autorepeat = false
-        servingsStepper.cornerRadius = 8.0
-        servingsStepper.buttonsFont = UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.bold)
-        servingsStepper.buttonsTextColor = Colors.highlightRed
-        servingsStepper.buttonsBackgroundColor = Colors.allWhite
-        servingsStepper.labelFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
-        servingsStepper.labelTextColor = Colors.textGrey
-        servingsStepper.labelBackgroundColor = Colors.allWhite
-        servingsStepper.borderWidth = 0
-        servingsStepper.borderColor = Colors.highlightRed
-        servingsStepper.labelWidthWeight = 0.4
-        servingsStepper.limitHitAnimationColor = Colors.paleGray
+        
+//        servingsStepper.minimumValue = 2
+//        servingsStepper.maximumValue = 12
+//        servingsStepper.stepValue = 1
+//        servingsStepper.value = Double(servings)
+//        servingsStepper.autorepeat = false
+//        servingsStepper.cornerRadius = 8.0
+//        servingsStepper.buttonsFont = UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.bold)
+//        servingsStepper.buttonsTextColor = Colors.highlightRed
+//        servingsStepper.buttonsBackgroundColor = Colors.allWhite
+//        servingsStepper.labelFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
+//        servingsStepper.labelTextColor = Colors.textGrey
+//        servingsStepper.labelBackgroundColor = Colors.allWhite
+//        servingsStepper.borderWidth = 0
+//        servingsStepper.borderColor = Colors.highlightRed
+//        servingsStepper.labelWidthWeight = 0.4
+//        servingsStepper.limitHitAnimationColor = Colors.paleGray
         
         separatorView.backgroundColor = Colors.seperatorGrey
         
@@ -119,6 +116,12 @@ class ManagementViewController: UIViewController {
             servingsStepper.isHidden = true
             separatorView.isHidden = true
         }
+        
+        if UIDevice.current.hasHomeButton {
+            bottomViewHeightConstraint.constant = 60
+            self.bottomView.layoutIfNeeded()
+        }
+        
     }
     
     private func setupSwipeGesture() {
@@ -219,11 +222,11 @@ class ManagementViewController: UIViewController {
 //        present(alert, animated: true, completion: nil)
     }
     @IBAction func didTapStepper2(_ sender: GMStepper) {
-        updateServings(servings: Int(sender.value))
+//        updateServings(servings: Int(sender.value))
     }
     
     @IBAction func didTapStepper(_ sender: UIStepper) {
-//        updateServings(servings: Int(sender.value))
+        updateServings(servings: Int(sender.value))
     }
     
     private func updateServings(servings: Int) {

--- a/LetsDinnerV2 MessagesExtension/Controller/ManagementVC/ManagementViewController.xib
+++ b/LetsDinnerV2 MessagesExtension/Controller/ManagementVC/ManagementViewController.xib
@@ -14,14 +14,15 @@
                 <outlet property="addThingView" destination="JOb-Ql-hbj" id="jkv-P8-dFA"/>
                 <outlet property="addThingViewBottomConstraint" destination="HfC-bK-eHS" id="pPW-gM-oLB"/>
                 <outlet property="backButton" destination="hfU-Un-jAU" id="k6Y-mn-IJ6"/>
+                <outlet property="bottomView" destination="d66-0o-BnV" id="L96-hW-mJ1"/>
+                <outlet property="bottomViewHeightConstraint" destination="HKD-88-rap" id="p9T-2R-vCK"/>
                 <outlet property="newThingTextField" destination="Zu2-hA-LyP" id="Ja7-aV-oaz"/>
                 <outlet property="nextButton" destination="haE-7o-ScL" id="OsG-bD-HEw"/>
-                <outlet property="progressView" destination="OCo-s0-ErQ" id="GAJ-PJ-p0v"/>
                 <outlet property="sectionSelectionInput" destination="XFi-HJ-Qmd" id="E31-6l-djZ"/>
                 <outlet property="separatorView" destination="b48-qc-gPw" id="1dF-Qo-RDr"/>
+                <outlet property="servingsFancyStepper" destination="nL2-l5-ann" id="Ule-a1-AOk"/>
                 <outlet property="servingsLabel" destination="0C6-a0-T8D" id="m7j-mw-SPR"/>
-                <outlet property="servingsStepper" destination="nL2-l5-ann" id="Ule-a1-AOk"/>
-                <outlet property="servingsStepperOld" destination="4kC-yC-Std" id="Muj-cV-JGR"/>
+                <outlet property="servingsStepper" destination="4kC-yC-Std" id="Muj-cV-JGR"/>
                 <outlet property="tasksTableView" destination="c6c-yo-AdS" id="YCm-JD-WNM"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -31,6 +32,12 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manage Things" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIB-AR-09T">
+                    <rect key="frame" x="126.5" y="16.5" width="122.5" height="20.5"/>
+                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hfU-Un-jAU">
                     <rect key="frame" x="17" y="10" width="82" height="33"/>
                     <constraints>
@@ -53,29 +60,47 @@
                         <action selector="didTapNext:" destination="-1" eventType="touchUpInside" id="qzl-kM-N3Z"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manage Things" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIB-AR-09T">
-                    <rect key="frame" x="126.5" y="16.5" width="122.5" height="20.5"/>
-                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="OCo-s0-ErQ">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dc8-Qe-sNb" userLabel="Top View">
+                    <rect key="frame" x="0.0" y="52" width="375" height="44"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How many servings?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0C6-a0-T8D">
+                            <rect key="frame" x="18" y="11.5" width="162" height="21"/>
+                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                            <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="4kC-yC-Std">
+                            <rect key="frame" x="263" y="7" width="94" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="hY3-oL-8FX"/>
+                            </constraints>
+                            <color key="tintColor" red="0.87843137250000003" green="0.38823529410000002" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <connections>
+                                <action selector="didTapStepper:" destination="-1" eventType="valueChanged" id="ZDz-Av-6fX"/>
+                            </connections>
+                        </stepper>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
-                        <constraint firstAttribute="height" id="GsZ-2N-E8V"/>
+                        <constraint firstItem="0C6-a0-T8D" firstAttribute="leading" secondItem="Dc8-Qe-sNb" secondAttribute="leading" constant="18" id="4n5-ho-Eex"/>
+                        <constraint firstAttribute="trailing" secondItem="4kC-yC-Std" secondAttribute="trailing" constant="18" id="J7z-ac-gCI"/>
+                        <constraint firstAttribute="height" constant="44" id="KG7-Sb-mrw"/>
+                        <constraint firstItem="4kC-yC-Std" firstAttribute="centerY" secondItem="Dc8-Qe-sNb" secondAttribute="centerY" id="dlD-Pd-CGo"/>
+                        <constraint firstItem="0C6-a0-T8D" firstAttribute="centerY" secondItem="Dc8-Qe-sNb" secondAttribute="centerY" id="uXL-5d-6wJ"/>
                     </constraints>
-                </progressView>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b48-qc-gPw">
+                    <rect key="frame" x="0.0" y="101" width="375" height="1"/>
+                    <color key="backgroundColor" white="0.6739351455479452" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="m12-Ei-D6k"/>
+                    </constraints>
+                </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="c6c-yo-AdS">
-                    <rect key="frame" x="0.0" y="114" width="375" height="483"/>
+                    <rect key="frame" x="0.0" y="102" width="375" height="495"/>
                 </tableView>
-                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="4kC-yC-Std">
-                    <rect key="frame" x="392" y="63" width="94" height="39"/>
-                    <connections>
-                        <action selector="didTapStepper:" destination="-1" eventType="valueChanged" id="ZDz-Av-6fX"/>
-                    </connections>
-                </stepper>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nL2-l5-ann" customClass="GMStepper" customModule="GMStepper">
-                    <rect key="frame" x="248" y="63" width="110" height="30"/>
+                    <rect key="frame" x="392" y="63" width="110" height="30"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="fzT-St-HLL"/>
@@ -100,19 +125,6 @@
                     <connections>
                         <action selector="didTapStepper2:" destination="-1" eventType="valueChanged" id="FvU-8g-EkS"/>
                     </connections>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How many servings?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0C6-a0-T8D">
-                    <rect key="frame" x="17" y="67.5" width="221" height="21"/>
-                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                    <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b48-qc-gPw">
-                    <rect key="frame" x="0.0" y="113" width="375" height="1"/>
-                    <color key="backgroundColor" white="0.6739351455479452" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="m12-Ei-D6k"/>
-                    </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JOb-Ql-hbj">
                     <rect key="frame" x="0.0" y="668" width="375" height="79"/>
@@ -178,8 +190,6 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="OCo-s0-ErQ" secondAttribute="trailing" id="1BL-NI-CxL"/>
-                <constraint firstItem="b48-qc-gPw" firstAttribute="top" secondItem="4kC-yC-Std" secondAttribute="bottom" constant="11" id="2Ch-HO-bxC"/>
                 <constraint firstItem="YIB-AR-09T" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="6Qu-UN-jWS"/>
                 <constraint firstItem="YIB-AR-09T" firstAttribute="centerY" secondItem="hfU-Un-jAU" secondAttribute="centerY" id="9pI-Wc-bcL"/>
                 <constraint firstItem="hfU-Un-jAU" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="10" id="CLF-eV-jtR"/>
@@ -189,24 +199,20 @@
                 <constraint firstItem="b48-qc-gPw" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="FO5-bI-k41"/>
                 <constraint firstItem="c6c-yo-AdS" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="FVb-nf-QJu"/>
                 <constraint firstItem="c6c-yo-AdS" firstAttribute="top" secondItem="b48-qc-gPw" secondAttribute="bottom" id="GrZ-dU-ZE5"/>
-                <constraint firstItem="nL2-l5-ann" firstAttribute="leading" secondItem="0C6-a0-T8D" secondAttribute="trailing" constant="10" id="H6V-NF-jCP"/>
                 <constraint firstAttribute="bottom" secondItem="JOb-Ql-hbj" secondAttribute="bottom" constant="-80" id="HfC-bK-eHS"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="haE-7o-ScL" secondAttribute="trailing" constant="17" id="I57-Ia-UAS"/>
-                <constraint firstItem="OCo-s0-ErQ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="IgC-7n-eeF"/>
                 <constraint firstItem="d66-0o-BnV" firstAttribute="top" secondItem="c6c-yo-AdS" secondAttribute="bottom" id="KIR-ZH-fTK"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="4kC-yC-Std" secondAttribute="leading" constant="-17" id="M5R-j7-CpB"/>
-                <constraint firstItem="b48-qc-gPw" firstAttribute="top" secondItem="nL2-l5-ann" secondAttribute="bottom" constant="20" id="MPE-pD-U8Z"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="nL2-l5-ann" secondAttribute="trailing" constant="17" id="NBt-Rs-0md"/>
+                <constraint firstItem="b48-qc-gPw" firstAttribute="top" secondItem="Dc8-Qe-sNb" secondAttribute="bottom" constant="5" id="MPE-pD-U8Z"/>
+                <constraint firstItem="nL2-l5-ann" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="17" id="QD4-Pv-CDa"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="d66-0o-BnV" secondAttribute="trailing" symbolic="YES" id="Qqw-6k-K7d"/>
                 <constraint firstItem="haE-7o-ScL" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="10" id="UGS-kx-BhI"/>
+                <constraint firstItem="Dc8-Qe-sNb" firstAttribute="top" secondItem="YIB-AR-09T" secondAttribute="bottom" constant="15" id="WbV-lq-lVx"/>
+                <constraint firstItem="Dc8-Qe-sNb" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="XAi-It-NOF"/>
                 <constraint firstItem="d66-0o-BnV" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Y6a-1S-Ku1"/>
-                <constraint firstItem="0C6-a0-T8D" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="17" id="ZzQ-bB-WGh"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="b48-qc-gPw" secondAttribute="trailing" id="aK2-yS-SHP"/>
-                <constraint firstItem="nL2-l5-ann" firstAttribute="centerY" secondItem="0C6-a0-T8D" secondAttribute="centerY" id="dEd-Rn-AYa"/>
-                <constraint firstItem="OCo-s0-ErQ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="dS2-gC-CYg"/>
-                <constraint firstItem="4kC-yC-Std" firstAttribute="top" secondItem="haE-7o-ScL" secondAttribute="bottom" constant="20" id="ebY-4K-NyN"/>
                 <constraint firstItem="JOb-Ql-hbj" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="gUj-fY-oAy"/>
                 <constraint firstItem="JOb-Ql-hbj" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="iHK-Ik-cjh"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Dc8-Qe-sNb" secondAttribute="trailing" id="mNb-bB-kyB"/>
                 <constraint firstAttribute="bottom" secondItem="d66-0o-BnV" secondAttribute="bottom" id="xQw-Kr-dIX"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/LetsDinnerV2 MessagesExtension/Controller/NewEventVC/NewEventViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/NewEventVC/NewEventViewController.swift
@@ -57,6 +57,7 @@ class NewEventViewController: UIViewController  {
         textFields.forEach { textField in
             textField!.delegate = self
             textField!.autocapitalizationType = .sentences
+            textField!.autocorrectionType = .no
         }
         scrollView.delegate = self
         infoInput.addButton.addTarget(self, action: #selector(didTapAdd), for: .touchUpInside)
@@ -319,10 +320,8 @@ extension NewEventViewController: UIScrollViewDelegate {
         scrollView.contentInset = UIEdgeInsets(top: headerViewHeight, left: 0, bottom: keyboardFrame.height, right: 0)
         scrollView.scrollIndicatorInsets = scrollView.contentInset
         
-        //Ipad have different frame height? UITextInputAssistantItem?
         var rectangle = self.view.frame
         rectangle.size.height -= keyboardFrame.height
-        
         
         if let activeField = activeField {
             if !rectangle.contains(activeField.frame.origin) {

--- a/LetsDinnerV2 MessagesExtension/Controller/ProgressVC/ProgressViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/ProgressVC/ProgressViewController.swift
@@ -44,7 +44,7 @@ class ProgressViewController: UIViewController {
 
             let progressFloat = Float(self.progress.fractionCompleted)
             
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { // Execute after Page animation
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { // Execute after Page animation
                 self.progressView.setProgress(progressFloat, animated: true)
             }
 

--- a/LetsDinnerV2 MessagesExtension/Controller/RecipeCreationVC/RecipeCreationViewController.xib
+++ b/LetsDinnerV2 MessagesExtension/Controller/RecipeCreationVC/RecipeCreationViewController.xib
@@ -169,8 +169,8 @@
                                         <action selector="didTapAddIngredient:" destination="-1" eventType="touchUpInside" id="kU9-IW-57K"/>
                                     </connections>
                                 </button>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Add an ingredient" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="MAi-Z2-qAd">
-                                    <rect key="frame" x="64" y="184" width="186" height="44"/>
+                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Milk" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="MAi-Z2-qAd">
+                                    <rect key="frame" x="64" y="184" width="191" height="44"/>
                                     <color key="tintColor" red="0.8784313725490196" green="0.38823529411764707" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="44" id="yuM-hI-d0H"/>
@@ -185,7 +185,7 @@
                                         <constraint firstAttribute="height" constant="1" id="zBH-PH-bbO"/>
                                     </constraints>
                                 </view>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Unit" textAlignment="center" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="4Rb-1T-tkm">
+                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="mL" textAlignment="center" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="4Rb-1T-tkm">
                                     <rect key="frame" x="320" y="184" width="40" height="44"/>
                                     <color key="tintColor" red="0.8784313725490196" green="0.38823529411764707" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
@@ -194,11 +194,11 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <textInputTraits key="textInputTraits"/>
                                 </textField>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Amount" textAlignment="center" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="0og-0o-pkv">
-                                    <rect key="frame" x="250" y="184" width="70" height="44"/>
+                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="30" textAlignment="right" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="0og-0o-pkv">
+                                    <rect key="frame" x="255" y="184" width="65" height="44"/>
                                     <color key="tintColor" red="0.8784313725490196" green="0.38823529411764707" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="oxK-kq-t0H"/>
+                                        <constraint firstAttribute="width" constant="65" id="oxK-kq-t0H"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
@@ -252,7 +252,7 @@
                                         <action selector="didTapAddStep:" destination="-1" eventType="touchUpInside" id="OuV-m2-86U"/>
                                     </connections>
                                 </button>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Add Step 1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sdW-3C-FYb">
+                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Step 1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sdW-3C-FYb">
                                     <rect key="frame" x="64" y="391" width="311" height="44"/>
                                     <color key="tintColor" red="0.8784313725490196" green="0.38823529411764707" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>

--- a/LetsDinnerV2 MessagesExtension/Controller/RecipesVC/RecipesViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/RecipesVC/RecipesViewController.swift
@@ -34,6 +34,9 @@ class RecipesViewController: UIViewController {
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var createRecipeButton: UIButton!
     @IBOutlet weak var recipeToggle: UIButton!
+    @IBOutlet weak var bottomView: UIView!
+    @IBOutlet weak var bottomViewHeightConstraint: NSLayoutConstraint!
+    
     
     weak var delegate: RecipesViewControllerDelegate?
     private let realm = try! Realm()
@@ -96,10 +99,10 @@ class RecipesViewController: UIViewController {
         searchLabel.isHidden = true
         resultsLabel.isHidden = true
         
-//        progressView.progressTintColor = Colors.newGradientRed
-//        progressView.trackTintColor = .white
-//        progressView.progress = 1/5
-//        progressView.setProgress(2/5, animated: true)
+        if UIDevice.current.hasHomeButton {
+            bottomViewHeightConstraint.constant = 60
+            self.bottomView.layoutIfNeeded()
+        }
     }
     
     private func setupSwipeGesture() {

--- a/LetsDinnerV2 MessagesExtension/Controller/RecipesVC/RecipesViewController.xib
+++ b/LetsDinnerV2 MessagesExtension/Controller/RecipesVC/RecipesViewController.xib
@@ -11,6 +11,8 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RecipesViewController" customModule="Let_s_Dinner_" customModuleProvider="target">
             <connections>
                 <outlet property="activityIndicator" destination="Ciq-25-awl" id="BfY-Mq-1MU"/>
+                <outlet property="bottomView" destination="bv3-Vn-pnT" id="cfI-Pe-Npq"/>
+                <outlet property="bottomViewHeightConstraint" destination="8DC-4H-tf8" id="ehf-gA-yM7"/>
                 <outlet property="createRecipeButton" destination="ulB-lg-UUU" id="qfd-vy-ZfB"/>
                 <outlet property="headerLabel" destination="Ay0-eE-nWy" id="BCc-Et-Wxz"/>
                 <outlet property="nextButton" destination="lhc-Ek-PZ3" id="GWK-61-TJ2"/>
@@ -98,7 +100,7 @@
                     <rect key="frame" x="0.0" y="584" width="375" height="83"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="bjE-MD-C37">
-                            <rect key="frame" x="17" y="15" width="341" height="33"/>
+                            <rect key="frame" x="17" y="13" width="341" height="33"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ulB-lg-UUU">
                                     <rect key="frame" x="0.0" y="0.0" width="33" height="33"/>
@@ -136,8 +138,8 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="83" id="8DC-4H-tf8"/>
                         <constraint firstAttribute="trailing" secondItem="bjE-MD-C37" secondAttribute="trailing" constant="17" id="KlV-gs-dd9"/>
+                        <constraint firstItem="bjE-MD-C37" firstAttribute="top" secondItem="bv3-Vn-pnT" secondAttribute="top" constant="13" id="TBe-Bf-Ces"/>
                         <constraint firstItem="bjE-MD-C37" firstAttribute="leading" secondItem="bv3-Vn-pnT" secondAttribute="leading" constant="17" id="Two-Hl-1cc"/>
-                        <constraint firstItem="bjE-MD-C37" firstAttribute="top" secondItem="bv3-Vn-pnT" secondAttribute="top" constant="15" id="vEu-1A-nfX"/>
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DISCOVER THESE RECIPES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ay0-eE-nWy">

--- a/LetsDinnerV2 MessagesExtension/Controller/ReviewVC/ReviewViewController.swift
+++ b/LetsDinnerV2 MessagesExtension/Controller/ReviewVC/ReviewViewController.swift
@@ -24,6 +24,7 @@ class ReviewViewController: UIViewController {
     @IBOutlet weak var buttonStackView: UIStackView!
     @IBOutlet weak var sendButtonLeadingConstraint: NSLayoutConstraint!
     @IBOutlet weak var seperatorLine: UIView!
+    @IBOutlet weak var topSendingLabel: UILabel!
     
     weak var delegate: ReviewViewControllerDelegate?
     
@@ -53,7 +54,6 @@ class ReviewViewController: UIViewController {
         setupUI()
         
         NotificationCenter.default.addObserver(self, selector: #selector(showUploadFail), name: Notification.Name(rawValue: "UploadError"), object: nil)
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -61,15 +61,17 @@ class ReviewViewController: UIViewController {
     }
 
     private func setupUI() {
-//        progressView.progressTintColor = Colors.newGradientRed
-//        progressView.trackTintColor = .white
-//        progressView.progress = 4/5
-//        progressView.setProgress(1, animated: true)
-        
         seperatorLine.backgroundColor = Colors.seperatorGrey
         summaryTableView.tableFooterView = UIView()
         
         sendButtonLeadingConstraint.isActive = false
+        
+        if #available(iOS 13.2, *) {
+            topSendingLabel.text = LabelStrings.readyToSend2
+        } else {
+            topSendingLabel.text = LabelStrings.readyToSend1
+        }
+
     }
     
     private func registerCell(_ nibName: String) {

--- a/LetsDinnerV2 MessagesExtension/Controller/ReviewVC/ReviewViewController.xib
+++ b/LetsDinnerV2 MessagesExtension/Controller/ReviewVC/ReviewViewController.xib
@@ -17,6 +17,7 @@
                 <outlet property="sendButtonLeadingConstraint" destination="AFb-Hv-JC5" id="WFY-61-DnF"/>
                 <outlet property="seperatorLine" destination="ohJ-Y0-Tgc" id="icI-E4-NrF"/>
                 <outlet property="summaryTableView" destination="ojl-GP-L7P" id="uzw-Cw-VGN"/>
+                <outlet property="topSendingLabel" destination="7B7-Wv-GEu" id="pmI-hY-O9f"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -25,7 +26,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You're all set now! 🦾 Ready to send your invite?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7B7-Wv-GEu">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You're all set now! 💪 Ready to send your invite?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7B7-Wv-GEu">
                     <rect key="frame" x="77.5" y="20" width="220" height="41"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="220" id="BVf-bU-Drd"/>

--- a/LetsDinnerV2 MessagesExtension/Extensions/UIDevice.swift
+++ b/LetsDinnerV2 MessagesExtension/Extensions/UIDevice.swift
@@ -1,0 +1,49 @@
+//
+//  UIDevice.swift
+//  LetsDinnerV2 MessagesExtension
+//
+//  Created by Alex Cheung on 10/2/2020.
+//  Copyright © 2020 Eric Ordonneau. All rights reserved.
+//
+import Foundation
+import UIKit
+
+public extension UIDevice {
+
+    enum `Type` {
+        case iPad
+        case iPhone_unknown
+        case iPhone_5_5S_5C
+        case iPhone_6_6S_7_8
+        case iPhone_6_6S_7_8_PLUS
+        case iPhone_X_Xs
+        case iPhone_Xs_11_Pro_Max
+        case iPhone_Xr_11
+        case iPhone_11_Pro
+    }
+
+     var hasHomeButton: Bool {
+        switch type {
+        case .iPhone_X_Xs, .iPhone_Xr_11, .iPhone_Xs_11_Pro_Max, .iPhone_11_Pro:
+            return false
+        default:
+            return true
+        }
+    }
+
+     var type: Type {
+        if userInterfaceIdiom == .phone {
+            switch UIScreen.main.nativeBounds.height {
+            case 1136: return .iPhone_5_5S_5C
+            case 1334: return .iPhone_6_6S_7_8
+            case 1920, 2208: return .iPhone_6_6S_7_8_PLUS
+            case 2436: return .iPhone_X_Xs
+            case 2688: return .iPhone_Xs_11_Pro_Max
+            case 1792: return .iPhone_Xr_11
+            case 2426: return .iPhone_11_Pro
+            default: return .iPhone_unknown
+        }
+        }
+        return .iPad
+   }
+}

--- a/LetsDinnerV2 MessagesExtension/Manager/TestCase.swift
+++ b/LetsDinnerV2 MessagesExtension/Manager/TestCase.swift
@@ -66,7 +66,7 @@ class testCase {
                                   
                               }
                               
-                          }
+                            }
                       }
                   
         }

--- a/LetsDinnerV2 MessagesExtension/Model/Constants.swift
+++ b/LetsDinnerV2 MessagesExtension/Model/Constants.swift
@@ -10,7 +10,6 @@ import UIKit
 
 let defaults = UserDefaults.standard
 
-
 enum VCNibs {
     static let initialViewController = "InitialViewController"
     static let registrationViewController = "RegistrationViewController"
@@ -106,4 +105,6 @@ enum LabelStrings {
     static let cookingTipsPlaceholder = "Anything else you want to mention?"
     static let update = "Update"
     static let selectNewDate = "Select a new date for your event:"
+    static let readyToSend1 = "You're all set now! 💪 \nReady to send your invite?"
+    static let readyToSend2 = "You're all set now! 🦾 \nReady to send your invite?"
 }

--- a/LetsDinnerV2.xcodeproj/project.pbxproj
+++ b/LetsDinnerV2.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		B8AED7D3239E357F00F2F633 /* CalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AED7D2239E357F00F2F633 /* CalendarManager.swift */; };
 		B8C4E82523E5ACDF00D752F1 /* ProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C4E82323E5ACDF00D752F1 /* ProgressViewController.swift */; };
 		B8C4E82623E5ACDF00D752F1 /* ProgressViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B8C4E82423E5ACDF00D752F1 /* ProgressViewController.xib */; };
+		B8D1CC9623F1309000E54E26 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D1CC9523F1309000E54E26 /* UIDevice.swift */; };
 		B8E4CA7823812157006DD095 /* TitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E4CA7723812157006DD095 /* TitleCell.swift */; };
 		B8E4CA7B238122AD006DD095 /* TitleCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B8E4CA7A238122AD006DD095 /* TitleCell.xib */; };
 /* End PBXBuildFile section */
@@ -282,6 +283,7 @@
 		B8AED7D2239E357F00F2F633 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		B8C4E82323E5ACDF00D752F1 /* ProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewController.swift; sourceTree = "<group>"; };
 		B8C4E82423E5ACDF00D752F1 /* ProgressViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProgressViewController.xib; sourceTree = "<group>"; };
+		B8D1CC9523F1309000E54E26 /* UIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDevice.swift; sourceTree = "<group>"; };
 		B8E4CA7723812157006DD095 /* TitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCell.swift; sourceTree = "<group>"; };
 		B8E4CA7A238122AD006DD095 /* TitleCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleCell.xib; sourceTree = "<group>"; };
 		BB96E7D51A8DA2E7C1222239 /* Pods-LetsDinnerV2.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LetsDinnerV2.release.xcconfig"; path = "Target Support Files/Pods-LetsDinnerV2/Pods-LetsDinnerV2.release.xcconfig"; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 				885C61132384B6D600ED3A17 /* UITextField.swift */,
 				880B135523746A5D003E29AC /* UIButton.swift */,
 				88B7832D23717D84009E4F3C /* UIColor.swift */,
+				B8D1CC9523F1309000E54E26 /* UIDevice.swift */,
 				88349F2B236F7145002A1879 /* UserDefaults.swift */,
 				88B7832F23717E3E009E4F3C /* String.swift */,
 				880B135923747578003E29AC /* Array.swift */,
@@ -1069,6 +1072,7 @@
 				88D33F0923A534C70061AD9A /* InfoInputView.swift in Sources */,
 				88B7833023717E3E009E4F3C /* String.swift in Sources */,
 				880B13692374BE0D003E29AC /* TasksListViewController.swift in Sources */,
+				B8D1CC9623F1309000E54E26 /* UIDevice.swift in Sources */,
 				88A362E3237EA8E2005B6B81 /* ManagementViewController.swift in Sources */,
 				B86F700B238521810010AB7C /* PrimaryButton.swift in Sources */,
 				88349F39237043BB002A1879 /* RecipesViewController.swift in Sources */,


### PR DESCRIPTION
- update on bottomView height on iphone8 or older
- back to native stepper
- Disable Autocorrect for the textfield in NewEventVC